### PR TITLE
K8s updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine AS builder
+FROM golang:1.13-alpine AS builder
 LABEL maintainer="Said Sef <saidsef@gmail.com>"
 
 ENV OPEN_FAAS 0.9.8

--- a/deployments/charts/faas-reverse-geocoding/Chart.yaml
+++ b/deployments/charts/faas-reverse-geocoding/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
-icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/d273e09/images/go.png
 name: faas-reverse-geocoding
 version: 0.1.0-SNAPSHOT

--- a/deployments/charts/faas-reverse-geocoding/Makefile
+++ b/deployments/charts/faas-reverse-geocoding/Makefile
@@ -1,4 +1,4 @@
-CHART_REPO := http://jenkins-x-chartmuseum:8080
+CHART_REPO := https://jenkins.saidsef.co.uk
 CURRENT=$(pwd)
 NAME := faas-reverse-geocoding
 OS := $(shell uname)

--- a/deployments/charts/faas-reverse-geocoding/templates/deployment.yaml
+++ b/deployments/charts/faas-reverse-geocoding/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}

--- a/deployments/charts/preview/Chart.yaml
+++ b/deployments/charts/preview/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
-icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/go.png
 name: preview
 version: 0.1.0-SNAPSHOT

--- a/deployments/charts/preview/Makefile
+++ b/deployments/charts/preview/Makefile
@@ -1,9 +1,7 @@
 OS := $(shell uname)
 
 preview:
-	helm init --client-only
-	helm repo add chartmuseum http://jenkins-x-chartmuseum:8080
-	helm repo add chartmuseum http://chartmuseum.jenkins-x.io
+	helm init
 ifeq ($(OS),Darwin)
 	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml

--- a/deployments/charts/preview/requirements.yaml
+++ b/deployments/charts/preview/requirements.yaml
@@ -1,13 +1,5 @@
 
 dependencies:
-- alias: expose
-  name: exposecontroller
-  repository: http://chartmuseum.jenkins-x.io
-  version: 2.3.56
-- alias: cleanup
-  name: exposecontroller
-  repository: http://chartmuseum.jenkins-x.io
-  version: 2.3.56
 - alias: preview
   name: faas-reverse-geocoding
   repository: file://../faas-reverse-geocoding


### PR DESCRIPTION
In this PR we've:
 - a6c89f4 removed deprecated references
 - fa2cb5e updated K8s deployment apiVersion
 - 0af4c6c updated K8s apiVersion
 - 75ea23c removed deprecated reference
 - 70efc74 updated golang omage tag to v1.13